### PR TITLE
Bumped Jinja requirement to handle Flask's requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ ecdsa==0.13.3
 Flask==1.0
 future==0.15.2
 itsdangerous==0.24
-Jinja2==2.8
+Jinja2>=2.10,<3.0
 MarkupSafe==0.23
 Naked==0.1.31
 vonage==2.5.3


### PR DESCRIPTION
Duplicate of #86, but this allows us to go up to v3 to make maintenance easier.