### PR TITLE
DEVX-6440: Updating whatsapp template snippets

### DIFF
--- a/messages/whatsapp/send_media_template.py
+++ b/messages/whatsapp/send_media_template.py
@@ -38,9 +38,9 @@ MEDIA_TEMPLATE = {
             {
                 "type": "body",
                 "parameters": [
-                    {"type": "text", "text": "Value 1"},
-                    {"type": "text", "text": "Value 2"},
-                    {"type": "text", "text": "Value 3"},
+                    "Value 1",
+                    "Value 2",
+                    "Value 3",
                 ],
             },
         ],

--- a/messages/whatsapp/send_template.py
+++ b/messages/whatsapp/send_template.py
@@ -30,9 +30,9 @@ client.messages.send_message(
         "template": {
             "name": f"{WHATSAPP_TEMPLATE_NAMESPACE}:{WHATSAPP_TEMPLATE_NAME}",
             "parameters": [
-                {"default": "Vonage Verification"},
-                {"default": "64873"},
-                {"default": "10"},
+                "Vonage Verification",
+                "64873",
+                "10",
             ],
         },
         "whatsapp": {"policy": "deterministic", "locale": "en-GB"},


### PR DESCRIPTION
Small change to the snippets for sending WhatsApp Template messages. The value for the `parameters` field was incorrect due to an error in the spec.